### PR TITLE
Update to include GIMP webinar

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
 
     <img src="https://avatars2.githubusercontent.com/u/51376973?v=4" width="200">
 <ul>
-    <li><a href="https://amazon.com">This is a link to Amazon.com!</a></li>
+    <li><a href="https://www.youtube.com/watch?v=kwymciQwZNU">This is a link to my Gimp webinar.  This webinar explains how to blur 
+      the background of a photo.  This webinar was created using the opensource software Free Cam.</a></li>
     <li>upromise.com</li>
   <li><a href="toni517b.github.io/FUMC Sound System.pdf" target="_blank">How to Operate the FUMC Sound System in a Pinch</a></li>
   <li><a href="toni517b.github.io/BCAUSEICANCODE Program Description.pdf" target="_blank">BCAUSEICANCODE Program Description</a></li>


### PR DESCRIPTION
Update to insert web link to YouTube for my GIMP webinar on blurring the foreground of a photo.